### PR TITLE
copy constructor is needed by std::map

### DIFF
--- a/Bytes.cpp
+++ b/Bytes.cpp
@@ -70,7 +70,7 @@ Bytes::~Bytes() {
         if (_start)
             free(_start);
 }
-Bytes::Bytes(Bytes& src) {
+Bytes::Bytes(const Bytes& src) {
     _start = (uint8_t*)malloc(src._capacity);
     _offset = 0;
     _limit = src._limit;

--- a/Bytes.h
+++ b/Bytes.h
@@ -25,7 +25,7 @@ class Bytes {
     Bytes(uint32_t size);
     Bytes(uint8_t* start, uint32_t size);
     Bytes& map(uint8_t* start, uint32_t size);
-    Bytes(Bytes& in);
+    Bytes(const Bytes& in);
     ~Bytes();
     Bytes& clone(Bytes& src);
     //    void map(uint8_t *start, uint32_t size);


### PR DESCRIPTION
The missing copy constructor caused the compilation problems on the rPI system (https://github.com/vortex314/serial2mqtt/issues/20).