### PR TITLE
fix CircBuf space calculations

### DIFF
--- a/CircBuf.cpp
+++ b/CircBuf.cpp
@@ -85,7 +85,7 @@ int   CircBuf::readFromIsr() {
 }
 
  uint32_t  CircBuf::space() {
-	return limit - size();
+	return limit - 2 - size();
 }
 
 bool  CircBuf::hasSpace() {
@@ -95,9 +95,9 @@ bool  CircBuf::hasSpace() {
 bool  CircBuf::hasSpace(uint32_t size) {
 	uint32_t next = (writePos + 1) % limit;
 	if (next <= readPos)
-		return (readPos > (next + size));
+		return (readPos >= (next + size));
 	else
-		return ((readPos + limit) > (next + size));
+		return ((readPos + limit) >= (next + size));
 }
 
 bool  CircBuf::hasData() { // not in  as it will be called in interrupt


### PR DESCRIPTION
During the investigation of the serial problem I've found two problems in the space calculation of the circular buffer.

This circular buffer implementation never let the read and write pointers be the same, that's why its capacity is `limit -2 `.
- start condition: `limit = 2, readPos = 0, writePos = 1`
  trying to write: `nextPos = 0` -> `ERROR`

The second problem is the space check:
- start condition: `limit = 3, readPos = 0, writePos = 1`
  hasSpace: `next = 2` -> `else` -> `3 >= 2 + size` -> `1 >= size`
- start condition: `limit = 3, readPos = 2, writePos = 0`
  hasSpace: `next = 1` -> `if` -> `2 >= 1 + size` -> `1 >= size`

Please check :-)