### PR TITLE
portability fixes for OpenWRT support

### DIFF
--- a/RtosQueue.cpp
+++ b/RtosQueue.cpp
@@ -1,4 +1,5 @@
 #include "RtosQueue.h"
+#include <sys/select.h>
 
 RtosQueue::~RtosQueue() {
 


### PR DESCRIPTION
This is the second part of the OpenWRT support. The MUSL libc doesn't contain the `pthread_getname_np()` function, so I had to reimplement it. The MUSL libc by definition has no feature test macro, so I assumed every linux system is based on MUSL which is not glibc (a configure test would be the proper solution, but it's an overkill).

If I remember correctly, the Alpine Linux has been switched to the MUSL libc, so this fix is necessary on that platform too.